### PR TITLE
Made grocer version minimum required for passbook notifs

### DIFF
--- a/passbook.gemspec
+++ b/passbook.gemspec
@@ -68,7 +68,7 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<rubyzip>, ["~> 1.0.0"])
-      s.add_runtime_dependency(%q<grocer>, [">= 0"])
+      s.add_runtime_dependency(%q<grocer>, ["~> 0.3"])
       s.add_runtime_dependency(%q<commander>, [">= 0"])
       s.add_runtime_dependency(%q<terminal-table>, [">= 0"])
       s.add_development_dependency(%q<rack-test>, [">= 0"])
@@ -80,7 +80,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<yard>, [">= 0"])
     else
       s.add_dependency(%q<rubyzip>, ["~> 1.0.0"])
-      s.add_dependency(%q<grocer>, [">= 0"])
+      s.add_dependency(%q<grocer>, ["~> 0.3"])
       s.add_dependency(%q<commander>, [">= 0"])
       s.add_dependency(%q<terminal-table>, [">= 0"])
       s.add_dependency(%q<rack-test>, [">= 0"])
@@ -93,7 +93,7 @@ Gem::Specification.new do |s|
     end
   else
     s.add_dependency(%q<rubyzip>, ["~> 1.0.0"])
-    s.add_dependency(%q<grocer>, [">= 0"])
+    s.add_dependency(%q<grocer>, ["~> 0.3"])
     s.add_dependency(%q<commander>, [">= 0"])
     s.add_dependency(%q<terminal-table>, [">= 0"])
     s.add_dependency(%q<rack-test>, [">= 0"])


### PR DESCRIPTION
Grocer only added passbook notifications for 0.3.0
https://github.com/grocer/grocer/commit/6d926ad9e7c5b7d03e5ca2b228bef4db640bc3db
