### PR TITLE
checking presence of only one type of icon image

### DIFF
--- a/lib/passbook/pkpass.rb
+++ b/lib/passbook/pkpass.rb
@@ -66,9 +66,10 @@ module Passbook
     private
 
     def checkPass manifest
-      # Check for default images
-      raise 'Icon missing' unless manifest.include?('icon.png')
-      raise 'Icon@2x missing' unless manifest.include?('icon@2x.png')
+      # Check for default images. We need only one icon version (retina preferred)
+      raise 'At least one icon file required' if %w{icon.png icon@2x.png}.none? do |icon|
+        manifest.include?(icon)
+      end
 
       # Check for developer field in JSON
       raise 'Pass Type Identifier missing' unless @pass.include?('passTypeIdentifier')


### PR DESCRIPTION
We actually don't need small icon if we have retina-sized. This is especially useful if you use only retina-sized images, as Apple Passbook downscales all of them for normal displays on-the-fly (if they are somewhere else remained :).
