### PR TITLE
update ancient (and buggy) rubyzip version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in passbook.gemspec
-gem 'rubyzip', '~> 1.0.0'
+gem 'rubyzip', '~> 1.1.6'
 gem 'grocer'
 gem 'commander'
 gem 'terminal-table'
@@ -12,6 +12,6 @@ group :test, :development do
   gem 'jeweler', :git => 'git://github.com/foxnewsnetwork/jeweler.git', :branch => 'ruby-2.0.0-ifying'
   gem 'simplecov'
   gem 'rspec'
-  gem 'rake' 
+  gem 'rake'
   gem 'yard'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ GEM
     rspec-expectations (2.14.3)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.3)
-    rubyzip (1.0.0)
+    rubyzip (1.1.6)
     simplecov (0.7.1)
       multi_json (~> 1.0)
       simplecov-html (~> 0.7.1)
@@ -59,7 +59,7 @@ DEPENDENCIES
   rack-test
   rake
   rspec
-  rubyzip (~> 1.0.0)
+  rubyzip (~> 1.1.6)
   simplecov
   terminal-table
   yard

--- a/passbook.gemspec
+++ b/passbook.gemspec
@@ -69,7 +69,7 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<rubyzip>, ["~> 1.0.0"])
+      s.add_runtime_dependency(%q<rubyzip>, ["~> 1.1.6"])
       s.add_runtime_dependency(%q<grocer>, [">= 0"])
       s.add_runtime_dependency(%q<commander>, [">= 0"])
       s.add_runtime_dependency(%q<terminal-table>, [">= 0"])
@@ -81,7 +81,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<rake>, [">= 0"])
       s.add_development_dependency(%q<yard>, [">= 0"])
     else
-      s.add_dependency(%q<rubyzip>, ["~> 1.0.0"])
+      s.add_dependency(%q<rubyzip>, ["~> 1.1.6"])
       s.add_dependency(%q<grocer>, [">= 0"])
       s.add_dependency(%q<commander>, [">= 0"])
       s.add_dependency(%q<terminal-table>, [">= 0"])
@@ -94,7 +94,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<yard>, [">= 0"])
     end
   else
-    s.add_dependency(%q<rubyzip>, ["~> 1.0.0"])
+    s.add_dependency(%q<rubyzip>, ["~> 1.1.6"])
     s.add_dependency(%q<grocer>, [">= 0"])
     s.add_dependency(%q<commander>, [">= 0"])
     s.add_dependency(%q<terminal-table>, [">= 0"])


### PR DESCRIPTION
Old version of rubyzip is full of bugs, (and holds me from updating it app-wide)
Check this out: https://github.com/rubyzip/rubyzip/blob/v1.0.0/lib/zip/file.rb#L119-L123
