### PR TITLE
rename p12_cert to p12_certificate

### DIFF
--- a/lib/rails/generators/passbook/config/templates/initializer.rb
+++ b/lib/rails/generators/passbook/config/templates/initializer.rb
@@ -6,8 +6,8 @@ Passbook.configure do |passbook|
   passbook.wwdc_cert = '<%= wwdc_cert_path %>'
 
   # Path to your cert.p12 file
-  passbook.p12_cert = '<%= p12_cert_path %>'
-  
+  passbook.p12_certificate = '<%= p12_cert_path %>'
+
   # Password for your certificate
   passbook.p12_password = '<%= p12_password %>'
 end


### PR DESCRIPTION
The passbook gem now uses `p12_certificate`, but the rails generator template still outputs `p12_cert`. This changes the generator template to match.