### PR TITLE
Pull out pusher into separate method

### DIFF
--- a/lib/passbook/push_notification.rb
+++ b/lib/passbook/push_notification.rb
@@ -1,10 +1,19 @@
 module Passbook
   class PushNotification
-    def self.send_notification(device_token)
-      pusher = Grocer.pusher({:certificate => Passbook.notification_cert, :passphrase => Passbook.notification_passphrase || "", :gateway => Passbook.notification_gateway})
-      notification = Grocer::PassbookNotification.new(:device_token => device_token)
+    class << self
+      def pusher
+        @pusher ||= Grocer.pusher(
+          :certificate => Passbook.notification_cert,
+          :passphrase => Passbook.notification_passphrase || "",
+          :gateway => Passbook.notification_gateway
+        )
+      end
 
-      pusher.push notification
+      def send_notification(device_token)
+        notification = Grocer::PassbookNotification.new(:device_token => device_token)
+
+        pusher.push notification
+      end
     end
   end
 end


### PR DESCRIPTION
Reuse pusher as per Apple's (and Grocer's) recommendation: https://github.com/grocer/grocer#sending-notifications

Also makes the pusher as configured by the app easily accessible during dev