### PR TITLE
require whole "grocer" gem

### DIFF
--- a/lib/passbook.rb
+++ b/lib/passbook.rb
@@ -3,7 +3,7 @@ require "passbook/pkpass"
 require "passbook/signer"
 require 'active_support/core_ext/module/attribute_accessors'
 require 'passbook/push_notification'
-require 'grocer/passbook_notification'
+require 'grocer'
 require 'rack/passbook_rack'
 
 module Passbook

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require 'rubygems'
 require 'bundler'
 require 'json'
 require 'simplecov'
-require 'grocer/passbook_notification'
+require 'grocer'
 SimpleCov.start
 
 Dir['lib/passbook/**/*.rb'].each {|f| require File.join(File.dirname(__FILE__), '..', f.gsub(/.rb/, ''))}


### PR DESCRIPTION
otherwise you won't load "lib/grocer.rb"
and you'll see `NoMethodError (undefined method `pusher' for Grocer:Module):` error.
when calling `Passbook::PushNotification.send_notification the_device_push_token`