### PR TITLE
certificate as binary

### DIFF
--- a/lib/passbook/signer.rb
+++ b/lib/passbook/signer.rb
@@ -32,9 +32,13 @@ module Passbook
         @key_hash[:key]  = OpenSSL::PKey::RSA.new File.read(key), password
         @key_hash[:cert] = OpenSSL::X509::Certificate.new File.read(certificate)
       else
-        p12 = OpenSSL::PKCS12.new File.read(certificate), password
+        p12 = OpenSSL::PKCS12.new certificate_data, password
         @key_hash[:key], @key_hash[:cert] = p12.key, p12.certificate
       end
+    end
+
+    def certificate_data
+      certificate.is_a?(Pathname) ? File.read(certificate) : certificate
     end
   end
 end

--- a/spec/lib/passbook/signer_spec.rb
+++ b/spec/lib/passbook/signer_spec.rb
@@ -34,7 +34,7 @@ describe 'Signer'  do
             OpenSSL::X509::Certificate.should_receive(:new).with('my_p12_certificate_file').and_return 'my_ssl_p12_cert'
           end
 
-          subject {Passbook::Signer.new(certificate: 'my_p12_certificate', password: 'password', 
+          subject {Passbook::Signer.new(certificate: 'my_p12_certificate', password: 'password',
                                         key: 'my_p12_key', wwdc_cert: 'i_love_robots').key_hash}
           its([:key]) {should eq 'my_rsa_key'}
           its([:cert]) {should eq 'my_ssl_p12_cert'}
@@ -44,16 +44,17 @@ describe 'Signer'  do
       context 'p12 files' do
         let (:p12) { double('OpenSSL::PKCS12') }
         let (:final_hash) {{:key => 'my_final_p12_key', :cert => 'my_final_p12_cert'}}
+        let (:cert_path) { Pathname.new('./my_p12_cert')}
         context 'using config file certificates' do
           before do
             p12.should_receive(:key).and_return final_hash[:key]
             p12.should_receive(:certificate).and_return final_hash[:cert]
             Passbook.should_receive(:p12_password).and_return 'password'
             Passbook.should_receive(:wwdc_cert).and_return 'i_love_robots'
-            Passbook.should_receive(:p12_certificate).and_return 'my_p12_cert'
+            Passbook.should_receive(:p12_certificate).and_return cert_path
             Passbook.should_receive(:p12_key).and_return nil
-            File.should_receive(:read).with('my_p12_cert').and_return 'my_p12_cert_file'
-            OpenSSL::PKCS12.should_receive(:new).with('my_p12_cert_file', 'password').and_return p12
+            File.should_receive(:read).with(cert_path).and_return 'my_p12_certificate_file'
+            OpenSSL::PKCS12.should_receive(:new).with('my_p12_certificate_file', 'password').and_return p12
           end
 
           subject {Passbook::Signer.new.key_hash}
@@ -69,11 +70,29 @@ describe 'Signer'  do
             Passbook.should_receive(:p12_key).never
             Passbook.should_receive(:p12_certificate).never
             Passbook.should_receive(:wwdc_cert).never
-            File.should_receive(:read).with('my_p12_cert').and_return 'my_p12_cert_file'
-            OpenSSL::PKCS12.should_receive(:new).with('my_p12_cert_file', 'password').and_return p12
+            File.should_receive(:read).with(cert_path).and_return 'my_p12_certificate_file'
+            OpenSSL::PKCS12.should_receive(:new).with('my_p12_certificate_file', 'password').and_return p12
           end
 
-          subject {Passbook::Signer.new(certificate: 'my_p12_cert', password: 'password', 
+          subject {Passbook::Signer.new(certificate: cert_path, password: 'password',
+                                        wwdc_cert: 'i_love_robots').key_hash}
+          its([:key]) {should eq final_hash[:key]}
+          its([:cert]) {should eq final_hash[:cert]}
+        end
+
+        context 'using passed in certificates as binary' do
+          before do
+            p12.should_receive(:key).and_return final_hash[:key]
+            p12.should_receive(:certificate).and_return final_hash[:cert]
+            Passbook.should_receive(:p12_password).never
+            Passbook.should_receive(:p12_key).never
+            Passbook.should_receive(:p12_certificate).never
+            Passbook.should_receive(:wwdc_cert).never
+            File.should_receive(:read).with(cert_path).and_return 'my_p12_certificate_file'
+            OpenSSL::PKCS12.should_receive(:new).with('my_p12_certificate_file', 'password').and_return p12
+          end
+
+          subject {Passbook::Signer.new(certificate: File.read(cert_path), password: 'password',
                                         wwdc_cert: 'i_love_robots').key_hash}
           its([:key]) {should eq final_hash[:key]}
           its([:cert]) {should eq final_hash[:cert]}


### PR DESCRIPTION
For multiple certificates which are saved on cloud, instead of creating TempFile we have binary data of certificate that is not Pathname.To add binary data as certificate support in signer.