### PR TITLE
Fix boarding pass template

### DIFF
--- a/lib/commands/templates/boarding-pass.json
+++ b/lib/commands/templates/boarding-pass.json
@@ -7,6 +7,13 @@
     "serialNumber" : "123456",
     "foregroundColor": "#866B23",
     "backgroundColor": "#FFD248",
+    "barcodes" : [
+        {
+            "message" : "DL123",
+            "format" : "PKBarcodeFormatQR",
+            "messageEncoding" : "iso-8859-1"
+        }
+    ],
     "boardingPass" : {
         "primaryFields" : [
             {
@@ -40,11 +47,6 @@
             }
         ],
         "transitType" : "PKTransitTypeAir",
-        "barcode" : {
-            "message" : "DL123",
-            "format" : "PKBarcodeFormatQR",
-            "messageEncoding" : "iso-8859-1"
-        },
         "backFields" : [
             {
                 "key" : "terms",


### PR DESCRIPTION
Fix the `barcode` key which is now deprecated in favour of `barcodes` (see https://developer.apple.com/library/archive/documentation/UserExperience/Reference/PassKit_Bundle/Chapters/TopLevel.html#//apple_ref/doc/uid/TP40012026-CH2-SW5).
In addition, `barcodes` key is now a top level key and not a child of `boardingPass`.